### PR TITLE
'compile' replaced with 'implementation'

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ allprojects {
 Add the ARCore-Location dependency. Replace `1.0.6` with the latest release from the [releases tab on Github](https://github.com/appoly/ARCore-Location/releases)
 ```
 dependencies {
-    compile 'com.github.appoly:ARCore-Location:1.0.6'
+    implementation 'com.github.appoly:ARCore-Location:1.0.6'
 }
 ```
 


### PR DESCRIPTION
Based on Gradle message:

WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html