### PR TITLE
remap height according to actual/render distance

### DIFF
--- a/arcore-location/src/main/java/uk/co/appoly/arcorelocation/LocationScene.java
+++ b/arcore-location/src/main/java/uk/co/appoly/arcorelocation/LocationScene.java
@@ -335,7 +335,11 @@ public class LocationScene {
                 marker.anchorNode.setScalingMode(marker.getScalingMode());
                 marker.anchorNode.setGradualScalingMaxScale(marker.getGradualScalingMaxScale());
                 marker.anchorNode.setGradualScalingMinScale(marker.getGradualScalingMinScale());
-                marker.anchorNode.setHeight(marker.getHeight());
+
+                // Locations further than RENDER_DISTANCE are remapped to be rendered closer.
+                // => height differential also has to ensure the remap is correct
+                float renderHeight = RENDER_DISTANCE * marker.getHeight() / markerDistance;
+                marker.anchorNode.setHeight(renderHeight);
 
                 if (minimalRefreshing)
                     marker.anchorNode.scaleAndRotate();

--- a/arcore-location/src/main/java/uk/co/appoly/arcorelocation/LocationScene.java
+++ b/arcore-location/src/main/java/uk/co/appoly/arcorelocation/LocationScene.java
@@ -338,8 +338,12 @@ public class LocationScene {
 
                 // Locations further than RENDER_DISTANCE are remapped to be rendered closer.
                 // => height differential also has to ensure the remap is correct
-                float renderHeight = RENDER_DISTANCE * marker.getHeight() / markerDistance;
-                marker.anchorNode.setHeight(renderHeight);
+                if (markerDistance > RENDER_DISTANCE) {
+                    float renderHeight = RENDER_DISTANCE * marker.getHeight() / markerDistance;
+                    marker.anchorNode.setHeight(renderHeight);
+                } else {
+                    marker.anchorNode.setHeight(marker.getHeight());
+                }
 
                 if (minimalRefreshing)
                     marker.anchorNode.scaleAndRotate();


### PR DESCRIPTION
Maybe I missed something or misunderstood how I should be using the library. I feel however that the current 'height' implementation doesn't work as expected.

Locations further than the render distance are remapped to a closer location, however the height of the original point is still being used.
As there's a significant difference between an object 100m high, 5m  away vs 1000m away I believe this should be recalculated.

In my fork I'm recalculating the height according to this difference which seems to render more correct results here.